### PR TITLE
refactor: simplify template code

### DIFF
--- a/.rustfmt.toml
+++ b/.rustfmt.toml
@@ -1,0 +1,3 @@
+indent_style="Block"
+reorder_imports=true
+binop_separator="Front"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -829,6 +829,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "paste"
+version = "1.0.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f746c4065a8fa3fe23974dd82f15431cc8d40779821001404d10d2e79ca7d79"
+
+[[package]]
 name = "pbkdf2"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1462,6 +1468,7 @@ dependencies = [
  "hex",
  "libflate",
  "minicbor",
+ "paste",
  "prost",
  "prost-build",
  "prost-types",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1452,7 +1452,7 @@ dependencies = [
 
 [[package]]
 name = "ur-parse-lib"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "hex",
  "ur",

--- a/libs/ur-parse-lib/Cargo.toml
+++ b/libs/ur-parse-lib/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ur-parse-lib"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/libs/ur-parse-lib/src/keystone_ur_decoder.rs
+++ b/libs/ur-parse-lib/src/keystone_ur_decoder.rs
@@ -1,11 +1,12 @@
 use alloc::string::{String, ToString};
+use alloc::vec::Vec;
 use core::fmt;
 use ur::ur::Kind;
 use ur_registry::error::{URError, URResult};
 use ur_registry::registry_types::{URType};
 use crate::ur::UR;
 
-pub fn probe_decode<T: ur_registry::traits::From<T>>(part: String) -> URResult<URParseResult<T>> {
+pub fn probe_decode<T: TryFrom<Vec<u8>, Error = URError>>(part: String) -> URResult<URParseResult<T>> {
     let mut ur_parse_result = URParseResult { is_multi_part: false, progress: 0, ur_type: None, data: None, decoder: None };
     let decoded = ur::decode(&part).map_err(|e| URError::UrDecodeError(e.to_string()))?;
     match decoded.0 {
@@ -29,6 +30,7 @@ pub fn probe_decode<T: ur_registry::traits::From<T>>(part: String) -> URResult<U
 }
 
 
+
 pub fn get_type(part: &String) -> URResult<URType> {
     let part = part.to_lowercase();
     let strip_scheme = part.strip_prefix("ur:").ok_or(URError::NotAUr)?;
@@ -41,7 +43,7 @@ pub struct KeystoneURDecoder {
 }
 
 impl KeystoneURDecoder {
-    pub fn parse_ur<T: ur_registry::traits::From<T>>(&mut self, part: String) -> URResult<MultiURParseResult<T>> {
+    pub fn parse_ur<T: TryFrom<Vec<u8>, Error = URError>>(&mut self, part: String) -> URResult<MultiURParseResult<T>> {
         let mut ur_parse_result = MultiURParseResult { is_complete: false, progress: 0, ur_type: None, data: None };
         self.decoder.receive(&part).map_err(|e| URError::UrDecodeError(e.to_string()))?;
         if self.decoder.complete() {

--- a/libs/ur-parse-lib/src/keystone_ur_encoder.rs
+++ b/libs/ur-parse-lib/src/keystone_ur_encoder.rs
@@ -2,19 +2,28 @@ use alloc::string::{String, ToString};
 use core::fmt;
 use ur_registry::error::{URError, URResult};
 
-pub fn probe_encode(message: &[u8],
-                    max_fragment_length: usize,
-                    ur_type: String, ) -> URResult<UREncodeResult> {
-    let mut encoder = ur::Encoder::new(
-        message,
-        max_fragment_length,
-        ur_type.clone(),
-    ).map_err(|e| URError::CborEncodeError(e.to_string()))?;
+pub fn probe_encode(
+    message: &[u8],
+    max_fragment_length: usize,
+    ur_type: String,
+) -> URResult<UREncodeResult> {
+    let mut encoder = ur::Encoder::new(message, max_fragment_length, ur_type.clone())
+        .map_err(|e| URError::CborEncodeError(e.to_string()))?;
     if encoder.fragment_count() > 1 {
-        Ok(UREncodeResult { is_multi_part: true, data: encoder.next_part().map_err(|e| URError::UrEncodeError(e.to_string()))?, encoder: Some(KeystoneUREncoder::new(encoder)) })
+        Ok(UREncodeResult {
+            is_multi_part: true,
+            data: encoder
+                .next_part()
+                .map_err(|e| URError::UrEncodeError(e.to_string()))?,
+            encoder: Some(KeystoneUREncoder::new(encoder)),
+        })
     } else {
         let ur = ur::encode(message, ur_type);
-        Ok(UREncodeResult { is_multi_part: false, data: ur, encoder: None })
+        Ok(UREncodeResult {
+            is_multi_part: false,
+            data: ur,
+            encoder: None,
+        })
     }
 }
 
@@ -43,7 +52,9 @@ impl KeystoneUREncoder {
     }
 
     pub fn next_part(&mut self) -> URResult<String> {
-        self.encoder.next_part().map_err(|e| URError::CborEncodeError(e.to_string()))
+        self.encoder
+            .next_part()
+            .map_err(|e| URError::CborEncodeError(e.to_string()))
     }
 
     pub fn current_index(&self) -> usize {
@@ -55,21 +66,22 @@ impl KeystoneUREncoder {
     }
 }
 
-
 #[cfg(test)]
 mod tests {
+    use crate::keystone_ur_encoder::probe_encode;
     use alloc::vec::Vec;
-    use ur_registry::crypto_psbt::CryptoPSBT;
-    use ur_registry::traits::{RegistryItem, To};
-    use crate::keystone_ur_encoder::{probe_encode};
     use hex::FromHex;
+    use ur_registry::crypto_psbt::CryptoPSBT;
+    use ur_registry::traits::{RegistryItem};
 
     #[test]
     fn test_encode() {
         let crypto = CryptoPSBT::new(
             Vec::from_hex("8c05c4b4f3e88840a4f4b5f155cfd69473ea169f3d0431b7a6787a23777f08aa8c05c4b4f3e88840a4f4b5f155cfd69473ea169f3d0431b7a6787a23777f08aa8c05c4b4f3e88840a4f4b5f155cfd69473ea169f3d0431b7a6787a23777f08aa8c05c4b4f3e88840a4f4b5f155cfd69473ea169f3d0431b7a6787a23777f08aa8c05c4b4f3e88840a4f4b5f155cfd69473ea169f3d0431b7a6787a23777f08aa8c05c4b4f3e88840a4f4b5f155cfd69473ea169f3d0431b7a6787a23777f08aa8c05c4b4f3e88840a4f4b5f155cfd69473ea169f3d0431b7a6787a23777f08aa8c05c4b4f3e88840a4f4b5f155cfd69473ea169f3d0431b7a6787a23777f08aa8c05c4b4f3e88840a4f4b5f155cfd69473ea169f3d0431b7a6787a23777f08aa8c05c4b4f3e88840a4f4b5f155cfd69473ea169f3d0431b7a6787a23777f08aa8c05c4b4f3e88840a4f4b5f155cfd69473ea169f3d0431b7a6787a23777f08aa8c05c4b4f3e88840a4f4b5f155cfd69473ea169f3d0431b7a6787a23777f08aa8c05c4b4f3e88840a4f4b5f155cfd69473ea169f3d0431b7a6787a23777f08aa8c05c4b4f3e88840a4f4b5f155cfd69473ea169f3d0431b7a6787a23777f08aa8c05c4b4f3e88840a4f4b5f155cfd69473ea169f3d0431b7a6787a23777f08aa8c05c4b4f3e88840a4f4b5f155cfd69473ea169f3d0431b7a6787a23777f08aa8c05c4b4f3e88840a4f4b5f155cfd69473ea169f3d0431b7a6787a23777f08aa8c05c4b4f3e88840a4f4b5f155cfd69473ea169f3d0431b7a6787a23777f08aa8c05c4b4f3e88840a4f4b5f155cfd69473ea169f3d0431b7a6787a23777f08aa8c05c4b4f3e88840a4f4b5f155cfd69473ea169f3d0431b7a6787a23777f08aa8c05c4b4f3e88840a4f4b5f155cfd69473ea169f3d0431b7a6787a23777f08aa8c05c4b4f3e88840a4f4b5f155cfd69473ea169f3d0431b7a6787a23777f08aa8c05c4b4f3e88840a4f4b5f155cfd69473ea169f3d0431b7a6787a23777f08aa8c05c4b4f3e88840a4f4b5f155cfd69473ea169f3d0431b7a6787a23777f08aa8c05c4b4f3e88840a4f4b5f155cfd69473ea169f3d0431b7a6787a23777f08aa8c05c4b4f3e88840a4f4b5f155cfd69473ea169f3d0431b7a6787a23777f08aa8c05c4b4f3e88840a4f4b5f155cfd69473ea169f3d0431b7a6787a23777f08aa")
                 .unwrap());
-        let result = probe_encode(&*(crypto.to_bytes().unwrap()), 400, CryptoPSBT::get_registry_type().get_type()).unwrap();
+        let result: Vec<u8> = crypto.try_into().unwrap();
+        let result =
+            probe_encode(&result, 400, CryptoPSBT::get_registry_type().get_type()).unwrap();
         assert_eq!("ur:crypto-psbt/1-3/lpadaxcfaxiacyvwhdfhndhkadclhkaxhnlkahssqzwfvslofzoxwkrewngotktbmwjkwdcmnefsaaehrlolkskncnktlbaypklkahssqzwfvslofzoxwkrewngotktbmwjkwdcmnefsaaehrlolkskncnktlbaypklkahssqzwfvslofzoxwkrewngotktbmwjkwdcmnefsaaehrlolkskncnktlbaypklkahssqzwfvslofzoxwkrewngotktbmwjkwdcmnefsaaehrlolkskncnktlbaypklkahssqzwfvslofzoxwkrewngotktbmwjkwdcmnefsaaehrlolkskncnktlbaypklkahssqzwfvslofzoxwkrewngotktbmwjkwdcmnefsaaehrlolkskncnktlbaypklkahssqzwfvslofzoxwkrewngotktbmwjkwdcmnefsaaehrlolkskncnktlbaypklkahssqzwfvslofzoxwkrewngotktbmwjkwdcmnefsaaehrlolkskncnktlbaypklkahssqzwfvslofzoxwkrewngotktbmwjkwdcmnefsaaehrlolkskncnktlbnychpmiy",
                    result.data);
         if result.is_multi_part {

--- a/libs/ur-parse-lib/src/ur.rs
+++ b/libs/ur-parse-lib/src/ur.rs
@@ -1,7 +1,6 @@
 use alloc::vec::Vec;
-use ur_registry::error::URResult;
+use ur_registry::error::{URError, URResult};
 use ur_registry::registry_types::URType;
-use ur_registry::traits::From;
 
 pub struct UR {
     ur_type: URType,
@@ -13,9 +12,8 @@ impl UR {
         UR { ur_type, data }
     }
 
-    pub fn parse<T: From<T>> (&self) -> URResult<(URType, T)> {
-        let result = T::from_cbor(self.data.clone())?;
+    pub fn parse<T: TryFrom<Vec<u8>, Error = URError>>(&self) -> URResult<(URType, T)> {
+        let result = T::try_from(self.data.clone())?;
         Ok((self.ur_type.clone(), result))
     }
-
 }

--- a/libs/ur-registry/Cargo.toml
+++ b/libs/ur-registry/Cargo.toml
@@ -17,7 +17,7 @@ prost = { version = "0.11.8", default-features = false }
 prost-types = { version = "0.11.8", default-features = false }
 libflate = { git = "https://github.com/KeystoneHQ/libflate.git", tag = "1.3.1", default-features = false, features = ["no_std"] }
 core2 = { version = "0.3", default_features = false, features = ["alloc"] }
-
+paste = "1.0.12"
 
 [build-dependencies]
 prost-build = { version = "0.11.8" }

--- a/libs/ur-registry/src/cardano/cardano_cert_key.rs
+++ b/libs/ur-registry/src/cardano/cardano_cert_key.rs
@@ -1,12 +1,12 @@
-use crate::cardano::cardano_utxo::CardanoUTXO;
+
 use crate::cbor::cbor_map;
 use crate::crypto_key_path::CryptoKeyPath;
 use crate::error::{URError, URResult};
 use crate::registry_types::CRYPTO_KEYPATH;
 use crate::traits::{From as FromCbor, MapSize, To};
 use crate::types::Bytes;
-use alloc::format;
-use alloc::string::String;
+
+
 use alloc::string::ToString;
 use alloc::vec::Vec;
 use core::convert::From;

--- a/libs/ur-registry/src/cardano/cardano_cert_key.rs
+++ b/libs/ur-registry/src/cardano/cardano_cert_key.rs
@@ -4,9 +4,13 @@ use core::convert::From;
 use minicbor::data::{Int, Tag};
 use minicbor::encode::{Error, Write};
 use minicbor::{Decoder, Encoder};
+use crate::cardano::cardano_utxo::CardanoUTXO;
 use crate::cbor::cbor_map;
 use crate::crypto_key_path::CryptoKeyPath;
 use crate::error::{URError, URResult};
+use alloc::format;
+use alloc::string::String;
+use crate::{impl_from_into_cbor_bytes, impl_ur_try_from_cbor_bytes, impl_ur_try_into_cbor_bytes};
 use crate::registry_types::CRYPTO_KEYPATH;
 use crate::traits::{To, From as FromCbor};
 use crate::types::Bytes;
@@ -94,3 +98,5 @@ impl FromCbor<CardanoCertKey> for CardanoCertKey {
         minicbor::decode(&bytes).map_err(|e| URError::CborDecodeError(e.to_string()))
     }
 }
+
+impl_from_into_cbor_bytes!(CardanoCertKey);

--- a/libs/ur-registry/src/cardano/cardano_cert_key.rs
+++ b/libs/ur-registry/src/cardano/cardano_cert_key.rs
@@ -1,62 +1,40 @@
+use crate::cardano::cardano_utxo::CardanoUTXO;
+use crate::cbor::cbor_map;
+use crate::crypto_key_path::CryptoKeyPath;
+use crate::error::{URError, URResult};
+use crate::registry_types::CRYPTO_KEYPATH;
+use crate::traits::{From as FromCbor, MapSize, To};
+use crate::types::Bytes;
+use alloc::format;
+use alloc::string::String;
 use alloc::string::ToString;
 use alloc::vec::Vec;
 use core::convert::From;
 use minicbor::data::{Int, Tag};
 use minicbor::encode::{Error, Write};
 use minicbor::{Decoder, Encoder};
-use crate::cardano::cardano_utxo::CardanoUTXO;
-use crate::cbor::cbor_map;
-use crate::crypto_key_path::CryptoKeyPath;
-use crate::error::{URError, URResult};
-use alloc::format;
-use alloc::string::String;
-use crate::{impl_from_into_cbor_bytes, impl_ur_try_from_cbor_bytes, impl_ur_try_into_cbor_bytes};
-use crate::registry_types::CRYPTO_KEYPATH;
-use crate::traits::{To, From as FromCbor};
-use crate::types::Bytes;
 
 const KEY_HASH: u8 = 1;
 const KEY_PATH: u8 = 2;
 
-#[derive(Debug, Clone, Default)]
-pub struct CardanoCertKey {
-    key_hash: Bytes,
-    key_path: CryptoKeyPath,
-}
+use crate::impl_template_struct;
 
-impl CardanoCertKey {
-    pub fn default() -> Self {
-        Default::default()
-    }
-    pub fn set_key_hash(&mut self, key_hash: Bytes) {
-        self.key_hash = key_hash;
-    }
-    pub fn set_key_path(&mut self, key_path: CryptoKeyPath) {
-        self.key_path = key_path;
-    }
-    pub fn get_key_hash(&self) -> Bytes {
-        self.key_hash.clone()
-    }
-    pub fn get_key_path(&self) -> CryptoKeyPath {
-        self.key_path.clone()
-    }
-    pub fn new(key_hash: Bytes, key_path: CryptoKeyPath) -> Self {
-        Self {
-            key_hash,
-            key_path,
-        }
-    }
-    fn get_map_size(&self) -> u64 {
+impl_template_struct!(CardanoCertKey {
+    key_hash: Bytes,
+    key_path: CryptoKeyPath
+});
+
+impl MapSize for CardanoCertKey {
+    fn map_size(&self) -> u64 {
         2
     }
 }
 
 impl<C> minicbor::Encode<C> for CardanoCertKey {
     fn encode<W: Write>(&self, e: &mut Encoder<W>, _ctx: &mut C) -> Result<(), Error<W::Error>> {
-        e.map(self.get_map_size())?;
+        e.map(self.map_size())?;
 
-        e.int(Int::from(KEY_HASH))?
-            .bytes(&self.get_key_hash())?;
+        e.int(Int::from(KEY_HASH))?.bytes(&self.get_key_hash())?;
 
         e.int(Int::from(KEY_PATH))?
             .tag(Tag::Unassigned(CRYPTO_KEYPATH.get_tag()))?;
@@ -70,7 +48,8 @@ impl<'b, C> minicbor::Decode<'b, C> for CardanoCertKey {
     fn decode(d: &mut Decoder<'b>, _ctx: &mut C) -> Result<Self, minicbor::decode::Error> {
         let mut cardano_cert_key = CardanoCertKey::default();
         cbor_map(d, &mut cardano_cert_key, |key, obj, d| {
-            let key = u8::try_from(key).map_err(|e| minicbor::decode::Error::message(e.to_string()))?;
+            let key =
+                u8::try_from(key).map_err(|e| minicbor::decode::Error::message(e.to_string()))?;
             match key {
                 KEY_HASH => {
                     obj.set_key_hash(d.bytes()?.to_vec());
@@ -98,5 +77,3 @@ impl FromCbor<CardanoCertKey> for CardanoCertKey {
         minicbor::decode(&bytes).map_err(|e| URError::CborDecodeError(e.to_string()))
     }
 }
-
-impl_from_into_cbor_bytes!(CardanoCertKey);

--- a/libs/ur-registry/src/cardano/cardano_sign_request.rs
+++ b/libs/ur-registry/src/cardano/cardano_sign_request.rs
@@ -3,8 +3,11 @@ use crate::cardano::cardano_utxo::CardanoUTXO;
 use crate::cbor::{cbor_array, cbor_map};
 use crate::crypto_key_path::CryptoKeyPath;
 use crate::error::{URError, URResult};
-use crate::registry_types::{RegistryType, CARDANO_SIGN_REQUEST, CRYPTO_KEYPATH, UUID, CARDANO_UTXO, CARDANO_CERT_KEY};
-use crate::traits::{From as FromCbor, RegistryItem, To};
+use crate::impl_template_struct;
+use crate::registry_types::{
+    RegistryType, CARDANO_CERT_KEY, CARDANO_SIGN_REQUEST, CARDANO_UTXO, CRYPTO_KEYPATH, UUID,
+};
+use crate::traits::{From as FromCbor, MapSize, RegistryItem, To};
 use crate::types::Bytes;
 use alloc::string::{String, ToString};
 use alloc::vec::Vec;
@@ -18,67 +21,10 @@ const UTXOS: u8 = 3;
 const CERT_KEYS: u8 = 4;
 const ORIGIN: u8 = 5;
 
-#[derive(Debug, Clone, Default)]
-pub struct CardanoSignRequest {
-    request_id: Option<Bytes>,
-    sign_data: Bytes,
-    utxos: Vec<CardanoUTXO>,
-    cert_keys: Vec<CardanoCertKey>,
-    origin: Option<String>,
-}
+impl_template_struct!(CardanoSignRequest {request_id: Option<Bytes>, sign_data: Bytes, utxos: Vec<CardanoUTXO>, cert_keys: Vec<CardanoCertKey>, origin: Option<String>});
 
-impl CardanoSignRequest {
-    pub fn default() -> Self {
-        Default::default()
-    }
-    pub fn set_request_id(&mut self, id: Option<Bytes>) {
-        self.request_id = id;
-    }
-    pub fn set_sign_data(&mut self, data: Bytes) {
-        self.sign_data = data
-    }
-    pub fn set_utxos(&mut self, utxos: Vec<CardanoUTXO>) {
-        self.utxos = utxos;
-    }
-    pub fn set_cert_keys(&mut self, cert_keys: Vec<CardanoCertKey>) {
-        self.cert_keys = cert_keys;
-    }
-    pub fn set_origin(&mut self, origin: Option<String>) {
-        self.origin = origin;
-    }
-    pub fn get_request_id(&self) -> Option<Bytes> {
-        self.request_id.clone()
-    }
-    pub fn get_sign_data(&self) -> Bytes {
-        self.sign_data.clone()
-    }
-    pub fn get_utxos(&self) -> Vec<CardanoUTXO> {
-        self.utxos.clone()
-    }
-    pub fn get_cert_keys(&self) -> Vec<CardanoCertKey> {
-        self.cert_keys.clone()
-    }
-    pub fn get_origin(&self) -> Option<String> {
-        self.origin.clone()
-    }
-
-    pub fn new(
-        request_id: Option<Bytes>,
-        sign_data: Bytes,
-        utxos: Vec<CardanoUTXO>,
-        cert_keys: Vec<CardanoCertKey>,
-        origin: Option<String>,
-    ) -> Self {
-        Self {
-            request_id,
-            sign_data,
-            utxos,
-            cert_keys,
-            origin,
-        }
-    }
-
-    fn get_map_size(&self) -> u64 {
+impl MapSize for CardanoSignRequest {
+    fn map_size(&self) -> u64 {
         let mut size = 3;
         if let Some(_) = self.request_id {
             size = size + 1;
@@ -98,7 +44,7 @@ impl RegistryItem for CardanoSignRequest {
 
 impl<C> minicbor::Encode<C> for CardanoSignRequest {
     fn encode<W: Write>(&self, e: &mut Encoder<W>, _ctx: &mut C) -> Result<(), Error<W::Error>> {
-        e.map(self.get_map_size())?;
+        e.map(self.map_size())?;
 
         if let Some(request_id) = &self.request_id {
             e.int(Int::from(REQUEST_ID))?
@@ -185,8 +131,6 @@ mod tests {
     use alloc::vec;
 
     extern crate std;
-
-    use std::println;
 
     #[test]
     fn test_construct() {

--- a/libs/ur-registry/src/cardano/cardano_sign_request.rs
+++ b/libs/ur-registry/src/cardano/cardano_sign_request.rs
@@ -129,7 +129,7 @@ mod tests {
     use super::*;
     use crate::crypto_key_path::PathComponent;
     use alloc::vec;
-
+    use crate::crypto_key_path::CryptoKeyPath;
     extern crate std;
 
     #[test]

--- a/libs/ur-registry/src/cardano/cardano_sign_request.rs
+++ b/libs/ur-registry/src/cardano/cardano_sign_request.rs
@@ -1,11 +1,11 @@
 use crate::cardano::cardano_cert_key::CardanoCertKey;
 use crate::cardano::cardano_utxo::CardanoUTXO;
 use crate::cbor::{cbor_array, cbor_map};
-use crate::crypto_key_path::CryptoKeyPath;
+
 use crate::error::{URError, URResult};
 use crate::impl_template_struct;
 use crate::registry_types::{
-    RegistryType, CARDANO_CERT_KEY, CARDANO_SIGN_REQUEST, CARDANO_UTXO, CRYPTO_KEYPATH, UUID,
+    RegistryType, CARDANO_CERT_KEY, CARDANO_SIGN_REQUEST, CARDANO_UTXO, UUID,
 };
 use crate::traits::{From as FromCbor, MapSize, RegistryItem, To};
 use crate::types::Bytes;
@@ -90,14 +90,14 @@ impl<'b, C> minicbor::Decode<'b, C> for CardanoSignRequest {
                     obj.set_sign_data(d.bytes()?.to_vec());
                 }
                 UTXOS => {
-                    cbor_array(d, &mut obj.utxos, |index, array, d| {
+                    cbor_array(d, &mut obj.utxos, |_index, array, d| {
                         d.tag()?;
                         array.push(CardanoUTXO::decode(d, _ctx)?);
                         Ok(())
                     })?;
                 }
                 CERT_KEYS => {
-                    cbor_array(d, &mut obj.cert_keys, |index, array, d| {
+                    cbor_array(d, &mut obj.cert_keys, |_index, array, d| {
                         d.tag()?;
                         array.push(CardanoCertKey::decode(d, _ctx)?);
                         Ok(())

--- a/libs/ur-registry/src/cardano/cardano_utxo.rs
+++ b/libs/ur-registry/src/cardano/cardano_utxo.rs
@@ -1,14 +1,15 @@
+use crate::cbor::cbor_map;
 use crate::crypto_key_path::CryptoKeyPath;
+use crate::error::{URError, URResult};
+use crate::impl_template_struct;
 use crate::registry_types::{RegistryType, CARDANO_UTXO, CRYPTO_KEYPATH};
-use crate::traits::{RegistryItem, To, From as FromCbor};
+use crate::traits::{From as FromCbor, MapSize, RegistryItem, To};
+use crate::types::Bytes;
 use alloc::string::{String, ToString};
 use alloc::vec::Vec;
 use minicbor::data::{Int, Tag};
 use minicbor::encode::{Error, Write};
 use minicbor::{Decoder, Encoder};
-use crate::cbor::cbor_map;
-use crate::error::{URError, URResult};
-use crate::types::Bytes;
 
 const TRANSACTION_HASH: u8 = 1;
 const INDEX: u8 = 2;
@@ -16,60 +17,16 @@ const AMOUNT: u8 = 3;
 const KEY_PATH: u8 = 4;
 const ADDRESS: u8 = 5;
 
-#[derive(Debug, Clone, Default)]
-pub struct CardanoUTXO {
+impl_template_struct!(CardanoUTXO {
     transaction_hash: Bytes,
     index: u32,
     amount: u64,
     key_path: CryptoKeyPath,
-    address: String,
-}
+    address: String
+});
 
-impl CardanoUTXO {
-    pub fn default() -> Self {
-        Default::default()
-    }
-    pub fn set_transaction_hash(&mut self, hash: Bytes) {
-        self.transaction_hash = hash;
-    }
-    pub fn set_index(&mut self, index: u32) {
-        self.index = index;
-    }
-    pub fn set_amount(&mut self, amount: u64) {
-        self.amount = amount;
-    }
-    pub fn set_key_path(&mut self, key_path: CryptoKeyPath) {
-        self.key_path = key_path;
-    }
-    pub fn set_address(&mut self, address: String) {
-        self.address = address;
-    }
-    pub fn get_transaction_hash(&self) -> Bytes {
-        self.transaction_hash.clone()
-    }
-    pub fn get_index(&self) -> u32 {
-        self.index.clone()
-    }
-    pub fn get_amount(&self) -> u64 {
-        self.amount.clone()
-    }
-    pub fn get_key_path(&self) -> CryptoKeyPath {
-        self.key_path.clone()
-    }
-    pub fn get_address(&self) -> String {
-        self.address.clone()
-    }
-    pub fn new(transaction_hash: Bytes, index: u32, amount: u64, key_path: CryptoKeyPath, address: String) -> Self {
-        Self {
-            transaction_hash,
-            index,
-            amount,
-            key_path,
-            address,
-        }
-    }
-
-    fn get_map_size(&self) -> u64 {
+impl MapSize for CardanoUTXO {
+    fn map_size(&self) -> u64 {
         5
     }
 }
@@ -82,24 +39,21 @@ impl RegistryItem for CardanoUTXO {
 
 impl<C> minicbor::Encode<C> for CardanoUTXO {
     fn encode<W: Write>(&self, e: &mut Encoder<W>, _ctx: &mut C) -> Result<(), Error<W::Error>> {
-        e.map(self.get_map_size())?;
+        e.map(self.map_size())?;
 
         e.int(Int::from(TRANSACTION_HASH))?
             .bytes(&self.get_transaction_hash())?;
 
-        e.int(Int::from(INDEX))?
-            .u32(self.get_index())?;
+        e.int(Int::from(INDEX))?.u32(self.get_index())?;
 
-        e.int(Int::from(AMOUNT))?
-            .u64(self.get_amount())?;
+        e.int(Int::from(AMOUNT))?.u64(self.get_amount())?;
 
         e.int(Int::from(KEY_PATH))?
             .tag(Tag::Unassigned(CRYPTO_KEYPATH.get_tag()))?;
 
         CryptoKeyPath::encode(&self.key_path, e, _ctx)?;
 
-        e.int(Int::from(ADDRESS))?
-            .str(&self.address)?;
+        e.int(Int::from(ADDRESS))?.str(&self.address)?;
 
         Ok(())
     }
@@ -109,17 +63,12 @@ impl<'b, C> minicbor::Decode<'b, C> for CardanoUTXO {
     fn decode(d: &mut Decoder<'b>, _ctx: &mut C) -> Result<Self, minicbor::decode::Error> {
         let mut cardano_utxo = CardanoUTXO::default();
         cbor_map(d, &mut cardano_utxo, |key, obj, d| {
-            let key = u8::try_from(key).map_err(|e| minicbor::decode::Error::message(e.to_string()))?;
+            let key =
+                u8::try_from(key).map_err(|e| minicbor::decode::Error::message(e.to_string()))?;
             match key {
-                TRANSACTION_HASH => {
-                    obj.set_transaction_hash(d.bytes()?.to_vec())
-                }
-                INDEX => {
-                    obj.set_index(d.u32()?)
-                }
-                AMOUNT => {
-                    obj.set_amount(d.u64()?)
-                }
+                TRANSACTION_HASH => obj.set_transaction_hash(d.bytes()?.to_vec()),
+                INDEX => obj.set_index(d.u32()?),
+                AMOUNT => obj.set_amount(d.u64()?),
                 KEY_PATH => {
                     d.tag()?;
                     obj.set_key_path(CryptoKeyPath::decode(d, _ctx)?);

--- a/libs/ur-registry/src/cardano/mod.rs
+++ b/libs/ur-registry/src/cardano/mod.rs
@@ -1,4 +1,4 @@
-pub mod cardano_sign_request;
-pub mod cardano_utxo;
-pub mod cardano_signature;
 pub mod cardano_cert_key;
+pub mod cardano_sign_request;
+pub mod cardano_signature;
+pub mod cardano_utxo;

--- a/libs/ur-registry/src/crypto_psbt.rs
+++ b/libs/ur-registry/src/crypto_psbt.rs
@@ -75,12 +75,13 @@ mod tests {
             psbt: Vec::from_hex("8c05c4b4f3e88840a4f4b5f155cfd69473ea169f3d0431b7a6787a23777f08aa")
                 .unwrap(),
         };
+        let result: Vec<u8> = crypto.try_into().unwrap();
         assert_eq!(
             "58208C05C4B4F3E88840A4F4B5F155CFD69473EA169F3D0431B7A6787A23777F08AA",
-            hex::encode(crypto.to_bytes().unwrap()).to_uppercase()
+            hex::encode::<Vec<u8>>(result.clone()).to_uppercase()
         );
 
-        let ur  = ur::encode(&*(crypto.to_bytes().unwrap()), CryptoPSBT::get_registry_type().get_type());
+        let ur  = ur::encode(&result, CryptoPSBT::get_registry_type().get_type());
         assert_eq!(ur, "ur:crypto-psbt/hdcxlkahssqzwfvslofzoxwkrewngotktbmwjkwdcmnefsaaehrlolkskncnktlbaypkvoonhknt");
     }
 
@@ -90,7 +91,7 @@ mod tests {
             "58208C05C4B4F3E88840A4F4B5F155CFD69473EA169F3D0431B7A6787A23777F08AA",
         )
             .unwrap();
-        let crypto = CryptoPSBT::from_cbor(bytes).unwrap();
+        let crypto = CryptoPSBT::try_from(bytes).unwrap();
         assert_eq!(crypto.get_psbt(), Vec::from_hex("8c05c4b4f3e88840a4f4b5f155cfd69473ea169f3d0431b7a6787a23777f08aa").unwrap());
     }
 }

--- a/libs/ur-registry/src/lib.rs
+++ b/libs/ur-registry/src/lib.rs
@@ -30,3 +30,21 @@ pub mod bytes;
 pub mod near;
 pub mod arweave;
 pub mod cardano;
+mod macros;
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    extern crate std;
+
+    use std::println;
+    use std::string::String;
+    use std::vec::Vec;
+    use crate::{impl_template_struct};
+    #[test]
+    fn test() {
+        impl_template_struct!(What {a: String, b: u32, c: Vec::<u8>});
+        let x = What::default();
+        x.get_a();
+    }
+}

--- a/libs/ur-registry/src/lib.rs
+++ b/libs/ur-registry/src/lib.rs
@@ -1,50 +1,33 @@
 #![no_std]
 #![feature(error_in_core)]
 
-extern crate core;
 extern crate alloc;
+extern crate core;
 
-
-pub mod registry_types;
-pub mod traits;
-mod types;
-pub mod error;
-pub mod crypto_psbt;
-pub mod crypto_key_path;
+pub mod aptos;
+pub mod arweave;
+pub mod bytes;
+pub mod cardano;
 mod cbor;
-pub mod crypto_coin_info;
-pub mod crypto_hd_key;
-pub mod crypto_ec_key;
-pub mod multi_key;
-pub mod script_expression;
-pub mod crypto_output;
+pub mod cosmos;
 pub mod crypto_account;
-pub mod solana;
+pub mod crypto_coin_info;
+pub mod crypto_ec_key;
+pub mod crypto_hd_key;
+pub mod crypto_key_path;
+pub mod crypto_output;
+pub mod crypto_psbt;
+pub mod error;
 pub mod ethereum;
 pub mod extend;
-pub mod cosmos;
-pub mod aptos;
 pub mod keystone;
-pub mod pb;
-pub mod bytes;
-pub mod near;
-pub mod arweave;
-pub mod cardano;
 mod macros;
-
-#[cfg(test)]
-mod test {
-    use super::*;
-    extern crate std;
-
-    use std::println;
-    use std::string::String;
-    use std::vec::Vec;
-    use crate::{impl_template_struct};
-    #[test]
-    fn test() {
-        impl_template_struct!(What {a: String, b: u32, c: Vec::<u8>});
-        let x = What::default();
-        x.get_a();
-    }
-}
+mod macros_impl;
+pub mod multi_key;
+pub mod near;
+pub mod pb;
+pub mod registry_types;
+pub mod script_expression;
+pub mod solana;
+pub mod traits;
+mod types;

--- a/libs/ur-registry/src/macros.rs
+++ b/libs/ur-registry/src/macros.rs
@@ -1,10 +1,9 @@
-use alloc::format;
 #[macro_export]
 macro_rules! impl_ur_try_from_cbor_bytes {
     ($name: ident) => {
-        impl TryFrom<Bytes> for $name {
+        impl TryFrom<Vec<u8>> for $name {
             type Error = URError;
-            fn try_from(value: Bytes) -> URResult<Self> {
+            fn try_from(value: Vec<u8>) -> URResult<Self> {
                 minicbor::decode(&value).map_err(|e| URError::CborDecodeError(e.to_string()))
             }
         }
@@ -14,10 +13,10 @@ macro_rules! impl_ur_try_from_cbor_bytes {
 #[macro_export]
 macro_rules! impl_ur_try_into_cbor_bytes {
     ($name: ident) => {
-        impl TryInto<Bytes> for $name {
+        impl TryInto<Vec<u8>> for $name {
             type Error = URError;
 
-            fn try_into(self) -> URResult<Bytes> {
+            fn try_into(self) -> URResult<Vec<u8>> {
                 minicbor::to_vec(self.clone()).map_err(|e| URError::CborDecodeError(e.to_string()))
             }
         }
@@ -25,14 +24,14 @@ macro_rules! impl_ur_try_into_cbor_bytes {
 }
 
 #[macro_export]
-macro_rules! impl_from_into_cbor_bytes {
-    ($name: ident) => {
-        impl_ur_try_from_cbor_bytes!($name);
-        impl_ur_try_into_cbor_bytes!($name);
+macro_rules! impl_cbor_bytes {
+    ($($name: ident,) *) => {
+        $(
+         impl_ur_try_from_cbor_bytes!($name);
+         impl_ur_try_into_cbor_bytes!($name);
+        )*
     };
 }
-
-use paste::paste;
 
 #[macro_export]
 macro_rules! impl_template_struct {
@@ -42,6 +41,16 @@ macro_rules! impl_template_struct {
             $(
               $field: $t,
             )*
+        }
+
+        impl $name {
+            pub fn new($($field: $t), *) -> Self {
+                Self {
+                    $(
+                        $field
+                    ), *
+                }
+            }
         }
 
         paste::item! {

--- a/libs/ur-registry/src/macros.rs
+++ b/libs/ur-registry/src/macros.rs
@@ -1,0 +1,60 @@
+use alloc::format;
+#[macro_export]
+macro_rules! impl_ur_try_from_cbor_bytes {
+    ($name: ident) => {
+        impl TryFrom<Bytes> for $name {
+            type Error = URError;
+            fn try_from(value: Bytes) -> URResult<Self> {
+                minicbor::decode(&value).map_err(|e| URError::CborDecodeError(e.to_string()))
+            }
+        }
+    };
+}
+
+#[macro_export]
+macro_rules! impl_ur_try_into_cbor_bytes {
+    ($name: ident) => {
+        impl TryInto<Bytes> for $name {
+            type Error = URError;
+
+            fn try_into(self) -> URResult<Bytes> {
+                minicbor::to_vec(self.clone()).map_err(|e| URError::CborDecodeError(e.to_string()))
+            }
+        }
+    };
+}
+
+#[macro_export]
+macro_rules! impl_from_into_cbor_bytes {
+    ($name: ident) => {
+        impl_ur_try_from_cbor_bytes!($name);
+        impl_ur_try_into_cbor_bytes!($name);
+    };
+}
+
+use paste::paste;
+
+#[macro_export]
+macro_rules! impl_template_struct {
+    ($name: ident { $($field: ident: $t: ty), *}) => {
+        #[derive(Debug, Clone, Default)]
+        pub struct $name {
+            $(
+              $field: $t,
+            )*
+        }
+
+        paste::item! {
+            impl $name {
+                $(
+                    pub fn [<get_ $field>](&self) -> $t {
+                        self.$field.clone()
+                    }
+                    pub fn [<set_ $field>](&mut self, $field: $t) {
+                        self.$field = $field
+                    }
+                )*
+            }
+        }
+    }
+}

--- a/libs/ur-registry/src/macros_impl.rs
+++ b/libs/ur-registry/src/macros_impl.rs
@@ -41,7 +41,7 @@ use crate::crypto_output::CryptoOutput;
 use crate::error::{URError, URResult};
 use alloc::vec::Vec;
 use crate::{impl_cbor_bytes, impl_ur_try_from_cbor_bytes, impl_ur_try_into_cbor_bytes};
-use alloc::string::{String, ToString};
+use alloc::string::{ToString};
 
 impl_cbor_bytes!(
     Bytes,

--- a/libs/ur-registry/src/macros_impl.rs
+++ b/libs/ur-registry/src/macros_impl.rs
@@ -1,0 +1,76 @@
+use crate::aptos::{aptos_sign_request::AptosSignRequest, aptos_signature::AptosSignature};
+use crate::arweave::{
+    arweave_crypto_account::ArweaveCryptoAccount, arweave_sign_request::ArweaveSignRequest,
+    arweave_signature::ArweaveSignature,
+};
+use crate::cardano::{
+    cardano_cert_key::CardanoCertKey, cardano_sign_request::CardanoSignRequest,
+    cardano_signature::CardanoSignature, cardano_utxo::CardanoUTXO,
+};
+use crate::cosmos::{
+    cosmos_sign_request::CosmosSignRequest,
+    cosmos_signature::CosmosSignature,
+};
+use crate::ethereum::{
+    eth_sign_request::EthSignRequest,
+    eth_signature::EthSignature,
+};
+use crate::extend::{
+    crypto_multi_accounts::CryptoMultiAccounts,
+};
+use crate::keystone::{
+    keystone_sign_request::KeystoneSignRequest,
+    keystone_sign_result::KeystoneSignResult,
+};
+use crate::near::{
+    near_sign_request::NearSignRequest,
+    near_signature::NearSignature,
+};
+use crate::solana::{
+    sol_sign_request::SolSignRequest,
+    sol_signature::SolSignature
+};
+use crate::bytes::Bytes;
+use crate::crypto_account::CryptoAccount;
+use crate::crypto_coin_info::CryptoCoinInfo;
+use crate::crypto_ec_key::CryptoECKey;
+use crate::crypto_hd_key::CryptoHDKey;
+use crate::crypto_key_path::CryptoKeyPath;
+use crate::crypto_psbt::CryptoPSBT;
+use crate::crypto_output::CryptoOutput;
+use crate::error::{URError, URResult};
+use alloc::vec::Vec;
+use crate::{impl_cbor_bytes, impl_ur_try_from_cbor_bytes, impl_ur_try_into_cbor_bytes};
+use alloc::string::{String, ToString};
+
+impl_cbor_bytes!(
+    Bytes,
+    CryptoAccount,
+    CryptoCoinInfo,
+    CryptoECKey,
+    CryptoHDKey,
+    CryptoKeyPath,
+    CryptoOutput,
+    CryptoPSBT,
+
+    CardanoSignature,
+    CardanoUTXO,
+    CardanoSignRequest,
+    CardanoCertKey,
+    AptosSignRequest,
+    AptosSignature,
+    ArweaveCryptoAccount,
+    ArweaveSignRequest,
+    ArweaveSignature,
+    CosmosSignRequest,
+    CosmosSignature,
+    EthSignRequest,
+    EthSignature,
+    CryptoMultiAccounts,
+    KeystoneSignRequest,
+    KeystoneSignResult,
+    NearSignRequest,
+    NearSignature,
+    SolSignRequest,
+    SolSignature,
+);

--- a/libs/ur-registry/src/registry_types.rs
+++ b/libs/ur-registry/src/registry_types.rs
@@ -1,53 +1,34 @@
-use alloc::string::{String, ToString};
 use crate::error::{URError, URResult};
+use alloc::string::{String, ToString};
 
 #[derive(Clone, Debug)]
 pub enum URType {
     CryptoPsbt(String),
     CryptoAccount(String),
     EthSignRequest(String),
-    Bytes(String)
+    Bytes(String),
 }
 
 impl URType {
     pub fn from(type_str: &str) -> URResult<URType> {
         match type_str {
-            "crypto-psbt" => {
-                Ok(URType::CryptoPsbt(type_str.to_string()))
-            }
-            "crypto-account" => {
-                Ok(URType::CryptoAccount(type_str.to_string()))
-            }
-            "bytes" => {
-                Ok(URType::Bytes(type_str.to_string()))
-            }
-            "eth-sign-request" => {
-                Ok(URType::EthSignRequest(type_str.to_string()))
-            }
-            _ => {
-                Err(URError::NotSupportURTypeError(type_str.to_string()))
-            }
+            "crypto-psbt" => Ok(URType::CryptoPsbt(type_str.to_string())),
+            "crypto-account" => Ok(URType::CryptoAccount(type_str.to_string())),
+            "bytes" => Ok(URType::Bytes(type_str.to_string())),
+            "eth-sign-request" => Ok(URType::EthSignRequest(type_str.to_string())),
+            _ => Err(URError::NotSupportURTypeError(type_str.to_string())),
         }
     }
 
     pub fn get_type_str(&self) -> String {
         match self {
-            URType::CryptoPsbt(type_str) => {
-                type_str.to_string()
-            }
-            URType::CryptoAccount(type_str) => {
-                type_str.to_string()
-            }
-            URType::Bytes(type_str) => {
-                type_str.to_string()
-            }
-            URType::EthSignRequest(type_str) => {
-                type_str.to_string()
-            }
-	}
+            URType::CryptoPsbt(type_str) => type_str.to_string(),
+            URType::CryptoAccount(type_str) => type_str.to_string(),
+            URType::Bytes(type_str) => type_str.to_string(),
+            URType::EthSignRequest(type_str) => type_str.to_string(),
+        }
     }
 }
-
 
 pub struct RegistryType<'a>(&'a str, Option<u64>);
 

--- a/libs/ur-registry/src/traits.rs
+++ b/libs/ur-registry/src/traits.rs
@@ -3,10 +3,12 @@ use crate::registry_types::RegistryType;
 use alloc::vec::Vec;
 
 pub trait From<T> {
+    #[deprecated(since="0.2.0", note="please use `try_from` instead")]
     fn from_cbor(bytes: Vec<u8>) -> URResult<T>;
 }
 
 pub trait To {
+    #[deprecated(since="0.2.0", note="please use `try_into` instead")]
     fn to_bytes(&self) -> URResult<Vec<u8>>;
 }
 

--- a/libs/ur-registry/src/traits.rs
+++ b/libs/ur-registry/src/traits.rs
@@ -1,6 +1,6 @@
-use alloc::vec::Vec;
-use crate::registry_types::RegistryType;
 use crate::error::URResult;
+use crate::registry_types::RegistryType;
+use alloc::vec::Vec;
 
 pub trait From<T> {
     fn from_cbor(bytes: Vec<u8>) -> URResult<T>;
@@ -16,4 +16,8 @@ pub trait UR {
 
 pub trait RegistryItem {
     fn get_registry_type() -> RegistryType<'static>;
+}
+
+pub trait MapSize {
+    fn map_size(&self) -> u64;
 }


### PR DESCRIPTION
Mainly change: 
1. add macro `impl_cbor_bytes` to implement try_from and try_into for ur types;
2. add macro `impl_template_structs` to reduce duplicated codes;
3. modify ur interface to use try_from and try_into;